### PR TITLE
tests/05_smoke_test: bug in tests_expended

### DIFF
--- a/tests/05_smoke_test:_golden.py
+++ b/tests/05_smoke_test:_golden.py
@@ -82,7 +82,7 @@ assert tests_expended(multfn, samples, complain=False) == 15
 assert tests_expended_corrected(multfn, samples) == 7  # gives 7
 # since `samples` is all ones, the order of turning the parts into rows
 # of the group test array should not matter, and so the below should match,
-# even though we changed the convention to large parts first in the utils code
+# even though we changed the convention to large pools first in the utils code
 assert empirical_tests_used(
     grouptest_array(multfn), samples
 ) == tests_expended_corrected(multfn, samples)


### PR DESCRIPTION
`tests_expended` was inaccurately computed the tests expended for the reason that the grouptest array matrix times the data matrix was giving the number of samples positive in a group, not the statuses. Hence the number of tests were overcounted, for example

```python
multfn = np.array([0, 0, 1, 1, 0, 0])
samples = np.ones((1,5))
tests_expended(multfn, samples) # gives 15, SHOULD give 2 + 3 + 2 = 7
tests_expended_corrected(multfn, samples) # gives 7
```
